### PR TITLE
Small fix for python 2 function

### DIFF
--- a/Python2/src/main/java/org/apache/asterix/external/library/ScikitLearnStringIntFunction.java
+++ b/Python2/src/main/java/org/apache/asterix/external/library/ScikitLearnStringIntFunction.java
@@ -76,8 +76,7 @@ public class ScikitLearnStringIntFunction implements IExternalScalarFunction {
         try {
 
             jep.set("data", text);
-            jep.eval("result = rdf.predict(data).tolist()");
-            jep.eval(" print(d.predict([\'I like it\']))");
+            jep.eval("result = pipeline.predict(data).tolist()");
 
             ArrayList<Integer> retArray = (ArrayList<Integer>)jep.getValue("result");
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Copy the serialized package into AsterixDB-Sklearn folder.
 	
 	cd ..
 
-	cp training/target/sentiment_pipeline AsterixDB-Sklearn/src/main/resources/
+	cp training/target/sentiment_pipeline AsterixDB-Sklearn/$PYTHON_VERSION/src/main/resources/
 
 ## <a name="udf">Select a Predefined UDF</a>
 


### PR DESCRIPTION
The 'rdf' variable didn't seem to exist in the init function, so it was breaking. Changing it seemed to work. 